### PR TITLE
Move the NODE_ENV variable to the environment vars section of the tra…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: node_js
 node_js:
     - stable
     - '0.12'
+env:
+    - NODE_ENV=development
 install:
-    - export NODE_ENV=development
     - npm install
     - cp _config/task.scripts.js test/mock-project/_config/task.scripts.js
     - cp package.json test/mock-project/package.json


### PR DESCRIPTION
## Description
Move the NODE_ENV variable to the environment variable section of the `.travisrc` file rather than doing it manually during the instal process

## Todos
> Make sure you’ve completed these:

- [x] Does this feature run on all supported platforms?
- [ ] Are there tests around this feature?
- [ ] Is there documentation for this feature?