### PR TITLE
fix(config): Add the components path to src

### DIFF
--- a/_config/task.scripts.js
+++ b/_config/task.scripts.js
@@ -8,7 +8,10 @@ function getTaskConfig(projectConfig) {
 			"destination": "./docs/gen"
 		  }
 		},
-		src: projectConfig.paths.src.scripts + '**/*.js',
+		src: [
+			projectConfig.paths.src.scripts + '**/*.js',
+			projectConfig.paths.src.components + '**/*.js'
+		],
 
 		jshint: {
 			"bitwise"       : true,


### PR DESCRIPTION
## Description
Added the components directory to the src by default

## Todos
> Make sure you’ve completed these:

- [x] Does this feature run on all supported platforms?
- [x] Are there tests around this feature?
- [ ] Is there documentation for this feature?

Added the path to the components directory in the task source